### PR TITLE
Fix for occasional lapse of anchoring issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,7 +67,7 @@ fastlane/test_output
 
 
 #macOS files
-.DS_STORE
+.DS_Store
 
 #cursor
 .cursor/


### PR DESCRIPTION
In this PR I modified DockMonitor.swift to:
- re-detect dock orientation when displays update,
- correct display sorting so the primary display is reliably first
- add handling for event-tap disabled notifications so the tap can recover when the system disables it.

This is to address the issue [Occasional lapse of anchoring](https://github.com/bwya77/DockAnchor/issues/5).

I tested this code for about a month without the issue reoccurring. The issue was happening quite often before.