### PR TITLE
feat: add customizable cursor position for dock relocation

### DIFF
--- a/DockAnchor/AppSettings.swift
+++ b/DockAnchor/AppSettings.swift
@@ -55,6 +55,12 @@ struct DockProfile: Identifiable, Codable, Equatable {
     }
 }
 
+enum CursorXPosition: String, CaseIterable {
+    case left = "Left"
+    case center = "Center"
+    case right = "Right"
+}
+
 class AppSettings: ObservableObject {
     static let shared = AppSettings()
 
@@ -104,6 +110,18 @@ class AppSettings: ObservableObject {
     @Published var appTheme: AppTheme {
         didSet {
             UserDefaults.standard.set(appTheme.rawValue, forKey: "appTheme")
+        }
+    }
+
+    @Published var cursorPosition: CursorXPosition {
+        didSet {
+            UserDefaults.standard.set(cursorPosition.rawValue, forKey: "cursorPosition")
+        }
+    }
+
+    @Published var cursorOffset: Double {
+        didSet {
+            UserDefaults.standard.set(cursorOffset, forKey: "cursorOffset")
         }
     }
 
@@ -168,6 +186,13 @@ class AppSettings: ObservableObject {
         // Get saved theme or default to system
         let savedTheme = UserDefaults.standard.string(forKey: "appTheme") ?? "System"
         self.appTheme = AppTheme(rawValue: savedTheme) ?? .system
+
+        // Get saved cursor position or default to center
+        let savedPosition = UserDefaults.standard.string(forKey: "cursorPosition") ?? "Center"
+        self.cursorPosition = CursorXPosition(rawValue: savedPosition) ?? .center
+        
+        // Get saved cursor offset or default to 50 pixels
+        self.cursorOffset = UserDefaults.standard.object(forKey: "cursorOffset") as? Double ?? 50.0
 
         // Load saved profiles
         self.profiles = Self.loadProfiles()

--- a/DockAnchor/ContentView.swift
+++ b/DockAnchor/ContentView.swift
@@ -607,95 +607,132 @@ struct SettingsView: View {
             Divider()
 
             // Content
-            VStack(spacing: 10) {
-                // Startup & Background
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Startup & Background")
-                        .font(.subheadline)
-                        .fontWeight(.semibold)
-                    Toggle("Start at Login", isOn: $appSettings.startAtLogin)
-                        .font(.callout)
-                        .toggleStyle(.switch)
-                    Toggle("Run in Background", isOn: $appSettings.runInBackground)
-                        .font(.callout)
-                        .toggleStyle(.switch)
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .cardStyle()
-
-                // Dock Behavior
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Dock Behavior")
-                        .font(.subheadline)
-                        .fontWeight(.semibold)
-                    Toggle("Auto-Move Dock", isOn: $appSettings.autoRelocateDock)
-                        .font(.callout)
-                        .toggleStyle(.switch)
-                    HStack {
-                        Text("Default Anchor")
+            ScrollView {
+                VStack(spacing: 10) {
+                    // Startup & Background
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Startup & Background")
+                            .font(.subheadline)
+                            .fontWeight(.semibold)
+                        Toggle("Start at Login", isOn: $appSettings.startAtLogin)
                             .font(.callout)
-                        Spacer()
-                        Picker("", selection: $appSettings.defaultAnchorDisplay) {
-                            ForEach(DefaultAnchorDisplay.allCases, id: \.self) { display in
-                                Text(display.rawValue).tag(display)
+                            .toggleStyle(.switch)
+                        Toggle("Run in Background", isOn: $appSettings.runInBackground)
+                            .font(.callout)
+                            .toggleStyle(.switch)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .cardStyle()
+
+                    // Dock Behavior
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Dock Behavior")
+                            .font(.subheadline)
+                            .fontWeight(.semibold)
+                        Toggle("Auto-Move Dock", isOn: $appSettings.autoRelocateDock)
+                            .font(.callout)
+                            .toggleStyle(.switch)
+                        HStack {
+                            Text("Default Anchor")
+                                .font(.callout)
+                            Spacer()
+                            Picker("", selection: $appSettings.defaultAnchorDisplay) {
+                                ForEach(DefaultAnchorDisplay.allCases, id: \.self) { display in
+                                    Text(display.rawValue).tag(display)
+                                }
+                            }
+                            .pickerStyle(.menu)
+                            .frame(width: 150)
+                        }
+                        Text("Used when anchor display is unavailable")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .cardStyle()
+
+                    // Cursor Position
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Cursor Position")
+                            .font(.subheadline)
+                            .fontWeight(.semibold)
+                        HStack {
+                            Picker("Position", selection: $appSettings.cursorPosition) {
+                                ForEach(CursorXPosition.allCases, id: \.self) { position in
+                                    Text(position.rawValue).tag(position)
+                                }
+                            }
+                            .pickerStyle(.segmented)
+                            .frame(width: 220)
+                            Spacer()
+                        }
+                        if appSettings.cursorPosition != .center {
+                            HStack {
+                                Text("Offset")
+                                    .font(.callout)
+                                Spacer()
+                                TextField("", value: $appSettings.cursorOffset, format: .number)
+                                    .textFieldStyle(.roundedBorder)
+                                    .frame(width: 80)
+                                Text("px")
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
                             }
                         }
-                        .pickerStyle(.menu)
-                        .frame(width: 150)
+                        Text("Horizontal cursor position when relocating dock")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
                     }
-                    Text("Used when anchor display is unavailable")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .cardStyle()
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .cardStyle()
 
-                // Interface
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Interface")
-                        .font(.subheadline)
-                        .fontWeight(.semibold)
-                    Toggle("Show Menu Bar Icon", isOn: $appSettings.showStatusIcon)
-                        .font(.callout)
-                        .toggleStyle(.switch)
-                    Toggle("Hide from Dock", isOn: $appSettings.hideFromDock)
-                        .font(.callout)
-                        .toggleStyle(.switch)
-                    HStack {
-                        Text("Theme")
+                    // Interface
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Interface")
+                            .font(.subheadline)
+                            .fontWeight(.semibold)
+                        Toggle("Show Menu Bar Icon", isOn: $appSettings.showStatusIcon)
                             .font(.callout)
-                        Spacer()
-                        Picker("", selection: $appSettings.appTheme) {
-                            ForEach(AppTheme.allCases, id: \.self) { theme in
-                                Text(theme.rawValue).tag(theme)
+                            .toggleStyle(.switch)
+                        Toggle("Hide from Dock", isOn: $appSettings.hideFromDock)
+                            .font(.callout)
+                            .toggleStyle(.switch)
+                        HStack {
+                            Text("Theme")
+                                .font(.callout)
+                            Spacer()
+                            Picker("", selection: $appSettings.appTheme) {
+                                ForEach(AppTheme.allCases, id: \.self) { theme in
+                                    Text(theme.rawValue).tag(theme)
+                                }
                             }
+                            .pickerStyle(.segmented)
+                            .frame(width: 180)
                         }
-                        .pickerStyle(.segmented)
-                        .frame(width: 180)
                     }
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .cardStyle()
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .cardStyle()
 
-                // Display Arrangement
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Display Arrangement")
-                        .font(.subheadline)
-                        .fontWeight(.semibold)
-                    DisplayArrangementView(
-                        displays: dockMonitor.availableDisplays,
-                        selectedDisplayUUID: $appSettings.selectedDisplayUUID,
-                        maxHeight: 60
-                    )
-                    Text("\(dockMonitor.availableDisplays.count) display(s) detected")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
+                    // Display Arrangement
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Display Arrangement")
+                            .font(.subheadline)
+                            .fontWeight(.semibold)
+                        DisplayArrangementView(
+                            displays: dockMonitor.availableDisplays,
+                            selectedDisplayUUID: $appSettings.selectedDisplayUUID,
+                            maxHeight: 60
+                        )
+                        Text("\(dockMonitor.availableDisplays.count) display(s) detected")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .cardStyle()
                 }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .cardStyle()
+                .padding(.horizontal)
+                .padding(.top, 12)
             }
-            .padding(.horizontal)
-            .padding(.top, 12)
 
             Spacer()
 

--- a/DockAnchor/DockMonitor.swift
+++ b/DockAnchor/DockMonitor.swift
@@ -12,6 +12,7 @@ import Carbon
 import CoreGraphics
 import Combine
 import IOKit
+import SwiftUI
 
 // MARK: - EDID Serial Number Extraction
 
@@ -747,10 +748,21 @@ class DockMonitor: NSObject, ObservableObject {
     private func getApproachPoint(for display: DisplayInfo) -> CGPoint {
         let frame = display.frame
         let offset: CGFloat = 50 // Start 50 pixels from the edge
+        let xPosition = CursorXPosition(rawValue: AppSettings.shared.cursorPosition.rawValue) ?? .center
+        let offsetValue = CGFloat(AppSettings.shared.cursorOffset)
 
         switch dockPosition {
         case .bottom:
-            return CGPoint(x: frame.midX, y: frame.maxY - offset)
+            var xPos: CGFloat
+            switch xPosition {
+            case .left:
+                xPos = frame.minX + offsetValue
+            case .center:
+                xPos = frame.midX
+            case .right:
+                xPos = frame.maxX - offsetValue
+            }
+            return CGPoint(x: xPos, y: frame.maxY - offset)
         case .left:
             return CGPoint(x: frame.minX + offset, y: frame.midY)
         case .right:
@@ -762,10 +774,21 @@ class DockMonitor: NSObject, ObservableObject {
     private func getPastEdgePoint(for display: DisplayInfo) -> CGPoint {
         let frame = display.frame
         let overshoot: CGFloat = 20 // Try to move 20 pixels past the edge
+        let xPosition = CursorXPosition(rawValue: AppSettings.shared.cursorPosition.rawValue) ?? .center
+        let offsetValue = CGFloat(AppSettings.shared.cursorOffset)
 
         switch dockPosition {
         case .bottom:
-            return CGPoint(x: frame.midX, y: frame.maxY + overshoot)
+            var xPos: CGFloat
+            switch xPosition {
+            case .left:
+                xPos = frame.minX + offsetValue
+            case .center:
+                xPos = frame.midX
+            case .right:
+                xPos = frame.maxX - offsetValue
+            }
+            return CGPoint(x: xPos, y: frame.maxY + overshoot)
         case .left:
             return CGPoint(x: frame.minX - overshoot, y: frame.midY)
         case .right:
@@ -776,11 +799,22 @@ class DockMonitor: NSObject, ObservableObject {
     /// Gets the point in the dock trigger zone for a display
     private func getDockTriggerPoint(for display: DisplayInfo) -> CGPoint {
         let frame = display.frame
+        let xPosition = CursorXPosition(rawValue: AppSettings.shared.cursorPosition.rawValue) ?? .center
+        let offsetValue = CGFloat(AppSettings.shared.cursorOffset)
 
         switch dockPosition {
         case .bottom:
-            // Bottom center of the display, at the very edge
-            return CGPoint(x: frame.midX, y: frame.maxY - 1)
+            var xPos: CGFloat
+            switch xPosition {
+            case .left:
+                xPos = frame.minX + offsetValue
+            case .center:
+                xPos = frame.midX
+            case .right:
+                xPos = frame.maxX - offsetValue
+            }
+            // Bottom edge of the display
+            return CGPoint(x: xPos, y: frame.maxY - 1)
         case .left:
             // Left center of the display, at the very edge
             return CGPoint(x: frame.minX + 1, y: frame.midY)

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ DockAnchor intercepts mouse movement events and blocks the dock from moving to s
 - **Check for Updates**: Automatically checks for new releases and updates
 - **Show DockAnchor**: Provides a simple way to access the app's main window
 - **Anchor Display**: Select which display the dock should remain on
+- **Cursor Position**: Customize horizontal cursor position (Left/Center/Right) with adjustable offset when relocating dock
 - **Status Monitoring**: Real-time feedback on protection status
 - **Primary Display Identification**: Displays the primary display in the settings
 - **App Theme**: Supports light, dark, and system themes


### PR DESCRIPTION
- Add CursorXPosition enum (Left/Center/Right)
- Add cursorPosition and cursorOffset settings in AppSettings
- Update DockMonitor to use configurable cursor position
- Add Cursor Position section in Settings UI with:
  - Segmented picker for Left/Center/Right
  - Offset input field (shown only for Left/Right)
- Default position: Center with 50px offset
- Update README with new feature

<img width="429" height="687" alt="image" src="https://github.com/user-attachments/assets/68977b63-1220-4a7a-8d8a-054601df9050" />
