### PR TITLE
Fix Dock sticking to primary monitor in multi-monitor post-wake

### DIFF
--- a/DockAnchor/DockMonitor.swift
+++ b/DockAnchor/DockMonitor.swift
@@ -99,6 +99,7 @@ class DockMonitor: NSObject, ObservableObject {
     private var dockPosition: DockPosition = .bottom
     private var cancellables = Set<AnyCancellable>()
     private var permissionCheckTimer: Timer?
+    private var pendingRelocationWork: DispatchWorkItem?
 
     /// Gets the current anchor display ID (derived from UUID)
     private var anchorDisplayID: CGDirectDisplayID {
@@ -236,6 +237,84 @@ class DockMonitor: NSObject, ObservableObject {
                 }
             }
             .store(in: &cancellables)
+
+        // Listen for system wake from sleep — catches wakes where the screen doesn't lock
+        // (e.g., "Require password after sleep: Never/5 minutes").
+        NSWorkspace.shared.notificationCenter.publisher(for: NSWorkspace.didWakeNotification)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.handleSystemWake()
+            }
+            .store(in: &cancellables)
+
+        // Listen for screen unlock — the most reliable trigger for the clamshell case.
+        // By the time the user authenticates, all displays are online and the Dock has
+        // already settled, so a much shorter stabilization delay is needed.
+        // This is a distributed notification posted by the macOS screensaver/lock mechanism.
+        DistributedNotificationCenter.default().publisher(for: Notification.Name("com.apple.screenIsUnlocked"))
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.handleScreenUnlock()
+            }
+            .store(in: &cancellables)
+    }
+
+    /// Schedules a dock relocation, cancelling any already-pending one.
+    /// All auto-relocation triggers (wake, unlock, display connect) funnel through
+    /// here so only ever one relocation sweep is queued at a time.
+    private func scheduleRelocation(after delay: TimeInterval) {
+        pendingRelocationWork?.cancel()
+        let work = DispatchWorkItem { [weak self] in
+            guard let self = self else { return }
+            self.pendingRelocationWork = nil
+            self.updateAvailableDisplays()
+            self.relocateDockToAnchoredDisplay()
+        }
+        pendingRelocationWork = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: work)
+    }
+
+    /// Re-anchors the dock after the system wakes from sleep.
+    /// macOS resets the Dock to the primary display on wake; this corrects it.
+    private func handleSystemWake() {
+        // Only proceed if the user has protection active or auto-relocate enabled
+        guard isMonitoring || AppSettings.shared.autoRelocateDock else { return }
+
+        statusMessage = "System woke from sleep — re-anchoring dock..."
+
+        // Do NOT call updateAvailableDisplays() here immediately. On wake, displays come
+        // back online one at a time. Calling it while only the primary display has registered
+        // would trigger validateCurrentAnchorDisplay() with a single-display list and could
+        // temporarily redirect the anchor away from the user's saved preference.
+
+        // Route through the shared scheduler so any later trigger (unlock, addFlag, etc.)
+        // cancels this and replaces it with its own — preventing a double sweep.
+        scheduleRelocation(after: 3.0)
+
+        // Retry at 8 s in case the first attempt fired before the Dock was ready.
+        // relocateDockToAnchoredDisplay() is a no-op when the dock is already correct,
+        // so this is always safe to call.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 8.0) { [weak self] in
+            guard let self = self else { return }
+            if let currentDock = self.getCurrentDockDisplayID(), currentDock != self.anchorDisplayID {
+                self.updateAvailableDisplays()
+                self.relocateDockToAnchoredDisplay()
+            }
+        }
+    }
+
+    /// Re-anchors the dock after the user unlocks the screen.
+    /// By unlock time all displays and the Dock are fully initialized, so only
+    /// a short stabilization delay is needed before relocating.
+    private func handleScreenUnlock() {
+        guard isMonitoring || AppSettings.shared.autoRelocateDock else { return }
+
+        statusMessage = "Screen unlocked — re-anchoring dock..."
+
+        // 1 s is enough: the display system is fully up by the time the user has
+        // authenticated. Routing through scheduleRelocation() cancels any pending
+        // wake or addFlag relocation so only one sweep fires.
+        scheduleRelocation(after: 1.0)
     }
 
     /// Gets the UUID of the built-in display (if available)
@@ -288,11 +367,15 @@ class DockMonitor: NSObject, ObservableObject {
     }
     
     private func validateCurrentAnchorDisplay() {
-        // If there's only one display, always select it
+        // If there's only one display, use it temporarily — but DON'T persist to AppSettings.
+        // On wake from sleep, displays come back online one at a time; overwriting
+        // selectedDisplayUUID here would permanently corrupt the user's saved preference
+        // before the second display has had a chance to register.
         if availableDisplays.count == 1, let onlyDisplay = availableDisplays.first {
             if anchorDisplayUUID != onlyDisplay.uuid {
                 anchorDisplayUUID = onlyDisplay.uuid
-                AppSettings.shared.selectedDisplayUUID = onlyDisplay.uuid
+                // Intentionally NOT updating AppSettings.selectedDisplayUUID here —
+                // same approach as the "anchor unavailable" path below.
             }
             return
         }
@@ -1350,9 +1433,7 @@ class DockMonitor: NSObject, ObservableObject {
 
                     // Auto-relocate dock if enabled (with delay to let display stabilize)
                     if AppSettings.shared.autoRelocateDock {
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
-                            self?.relocateDockToAnchoredDisplay()
-                        }
+                        scheduleRelocation(after: 1.0)
                     }
                 }
 
@@ -1391,7 +1472,15 @@ class DockMonitor: NSObject, ObservableObject {
                         self.statusMessage = "Dock Anchor Ready"
                     }
                 }
-            } else if flags.contains(.enabledFlag) || flags.contains(.disabledFlag) {
+            } else if flags.contains(.enabledFlag) {
+                // A display was re-enabled (e.g., monitor waking from display sleep).
+                // Delay the display list refresh — firing it immediately while other displays
+                // are still coming back online can cause validateCurrentAnchorDisplay() to
+                // see a partial list and temporarily misdirect the anchor.
+                DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) { [weak self] in
+                    self?.updateAvailableDisplays()
+                }
+            } else if flags.contains(.disabledFlag) {
                 self.updateAvailableDisplays()
             } else if flags.contains(.movedFlag) || flags.contains(.desktopShapeChangedFlag) {
                 // Display was moved/rearranged or desktop shape changed
@@ -1432,9 +1521,7 @@ class DockMonitor: NSObject, ObservableObject {
 
                             // Auto-relocate dock if enabled
                             if AppSettings.shared.autoRelocateDock {
-                                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
-                                    self?.relocateDockToAnchoredDisplay()
-                                }
+                                scheduleRelocation(after: 0.5)
                             }
 
                             // Reset status message after 3 seconds


### PR DESCRIPTION
## Problem

On a multi-monitor setup using a MacBook in clamshell mode, the Dock resets to the primary display when the machine wakes from sleep. DockAnchor was not correcting this, leaving the Dock stranded on the wrong display until the user manually intervened.

Two separate behaviors were responsible:

### Behavior 1 — Anchor preference silently corrupted on wake

When waking from sleep, displays come back online one at a time. Each display firing its `.enabledFlag` reconfiguration callback triggered `updateAvailableDisplays()`, which called `validateCurrentAnchorDisplay()`. If only one display had registered at that moment, the single-display branch would permanently overwrite `AppSettings.selectedDisplayUUID` with whichever display came online first (typically the primary). By the time both displays were available and a relocation was attempted, the saved anchor preference had already been changed to the wrong display.

### Behavior 2 — No wake or unlock event handling

DockAnchor only triggered dock relocation on `CGDisplayReconfigurationCallback` events (display added, mode changed, primary changed). On a clamshell wake with the same displays connected, none of these fire — the display configuration hasn't changed, it just went to sleep and came back. There was no code path that detected wake from sleep and re-anchored the dock.

## Changes

### `validateCurrentAnchorDisplay()` — don't persist to AppSettings in the single-display case

The `count == 1` branch previously wrote to `AppSettings.selectedDisplayUUID`, permanently overwriting the user's saved preference during the transient window when only one display is registered. It now only updates the in-memory `anchorDisplayUUID`, consistent with how the "anchor unavailable" path already behaves. The user's preference is preserved and the correct anchor is restored once all displays are online.

### Wake from sleep handling — `NSWorkspace.didWakeNotification`

Registers a new `handleSystemWake()` handler that schedules a dock relocation 3 seconds after wake, giving the Window Server and Dock process time to fully restart. A secondary check at 8 seconds retries if the dock is still on the wrong display. This covers cases where the screen does not lock on sleep (e.g., "Require password: Never").

### Screen unlock handling — `com.apple.screenIsUnlocked`

Registers a new `handleScreenUnlock()` handler on the distributed notification center. By the time the user authenticates at the lock screen, all displays are fully online and the Dock has already settled, so a 1-second stabilization delay is sufficient. This is the most reliable trigger for the clamshell wake + lock screen workflow.

### Shared relocation scheduler — `scheduleRelocation(after:)`

Introduces a single `DispatchWorkItem`-based scheduler that all auto-relocation triggers funnel through. Each call cancels any pending work before scheduling new work. This prevents multiple triggers firing in close succession (wake notification + display `.addFlag` + screen unlock) from each independently queuing a relocation and producing multiple dock sweeps. The `.addFlag` and `.setMainFlag` display config handlers are updated to use this scheduler.

### `.enabledFlag` display callback — delayed refresh

The `.enabledFlag` and `.disabledFlag` display reconfiguration paths are split. The enabled path (monitor waking) delays its `updateAvailableDisplays()` call by 2 seconds rather than firing immediately, avoiding a race where `validateCurrentAnchorDisplay()` sees a partial display list while monitors are still coming online.

## Behavior changes to be aware of

- **Single-monitor users:** `validateCurrentAnchorDisplay()` no longer auto-syncs `AppSettings.selectedDisplayUUID` when only one display is present. If the saved UUID somehow becomes stale on a single-monitor machine, it will no longer self-heal automatically. The anchor display can always be corrected manually via the UI.
- **`.enabledFlag` display list refresh:** When a monitor wakes from display sleep (not system sleep), the available display list in the UI now refreshes after a 2-second delay rather than immediately. Dock protection and anchor logic are unaffected.
- **Multiple simultaneous display connections:** When connecting multiple displays at once, only one relocation fires instead of one per display. This is an improvement in practice.

## Testing

- MacBook in clamshell mode with two external monitors
- Sleep machine, wake, unlock at lock screen then dock should re-anchor within ~1 second of unlock
- Sleep machine without lock screen then dock should re-anchor within ~3 seconds of wake
- Connect/disconnect individual monitors then existing auto-relocate behavior unchanged
- Single-monitor setup then anchor selection and protection behave as before