### PR TITLE
Fix notarization: strip debug entitlement

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,8 @@ jobs:
             CODE_SIGN_STYLE=Manual \
             CODE_SIGN_IDENTITY="Developer ID Application" \
             DEVELOPMENT_TEAM="${{ secrets.APPLE_TEAM_ID }}" \
-            OTHER_CODE_SIGN_FLAGS="--keychain $RUNNER_TEMP/app-signing.keychain-db --timestamp"
+            OTHER_CODE_SIGN_FLAGS="--keychain $RUNNER_TEMP/app-signing.keychain-db --timestamp" \
+            CODE_SIGN_INJECT_BASE_ENTITLEMENTS=NO
 
       - name: Find App Bundle
         id: app


### PR DESCRIPTION
Strips com.apple.security.get-task-allow via CODE_SIGN_INJECT_BASE_ENTITLEMENTS=NO