### PR TITLE
Fix update check missing patch releases when running a shorter version string

### DIFF
--- a/DockAnchor/UpdateChecker.swift
+++ b/DockAnchor/UpdateChecker.swift
@@ -90,33 +90,33 @@ class UpdateChecker: ObservableObject {
     }
     
     private func isNewerVersion(_ latestVersion: String) -> Bool {
+        return Self.isVersionNewer(latestVersion, than: currentVersion)
+    }
+
+    /// Compares two dot-separated version strings (e.g. "2.1.5" vs "2.1").
+    /// A missing trailing component is treated as 0, so versions with a
+    /// different number of components still compare correctly - a release
+    /// tagged "2.1.5" is recognized as newer than a running "2.1" build.
+    /// Exposed as a static, self-contained function so it can be unit
+    /// tested without touching the network or app singletons.
+    static func isVersionNewer(_ latestVersion: String, than currentVersion: String) -> Bool {
         let currentComponents = currentVersion.split(separator: ".").compactMap { Int($0) }
         let latestComponents = latestVersion.split(separator: ".").compactMap { Int($0) }
-        
+
         // Ensure both versions have at least major and minor components
         guard currentComponents.count >= 2, latestComponents.count >= 2 else {
             return false
         }
-        
-        // Compare major version
-        if latestComponents[0] > currentComponents[0] {
-            return true
-        } else if latestComponents[0] < currentComponents[0] {
-            return false
+
+        let componentCount = max(currentComponents.count, latestComponents.count)
+        for index in 0..<componentCount {
+            let current = index < currentComponents.count ? currentComponents[index] : 0
+            let latest = index < latestComponents.count ? latestComponents[index] : 0
+            if latest != current {
+                return latest > current
+            }
         }
-        
-        // Compare minor version
-        if latestComponents[1] > currentComponents[1] {
-            return true
-        } else if latestComponents[1] < currentComponents[1] {
-            return false
-        }
-        
-        // Compare patch version if available
-        if currentComponents.count >= 3 && latestComponents.count >= 3 {
-            return latestComponents[2] > currentComponents[2]
-        }
-        
+
         return false
     }
     

--- a/DockAnchorTests/DockAnchorTests.swift
+++ b/DockAnchorTests/DockAnchorTests.swift
@@ -10,8 +10,43 @@ import Testing
 
 struct DockAnchorTests {
 
-    @Test func example() async throws {
-        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    // MARK: - UpdateChecker.isVersionNewer
+
+    @Test func patchBumpWithMatchingComponentCountIsDetected() async throws {
+        #expect(UpdateChecker.isVersionNewer("2.1.1", than: "2.1.0") == true)
+    }
+
+    @Test func patchBumpAgainstShorterCurrentVersionIsDetected() async throws {
+        // Regression check: a running version with no patch component ("2.1")
+        // must still see a patch-only release ("2.1.5") as newer.
+        #expect(UpdateChecker.isVersionNewer("2.1.5", than: "2.1") == true)
+    }
+
+    @Test func shorterLatestVersionIsNotTreatedAsOlder() async throws {
+        // "2.1" is missing a patch component, so it's compared as "2.1.0"
+        // against a current version of "2.1.5" - not newer.
+        #expect(UpdateChecker.isVersionNewer("2.1", than: "2.1.5") == false)
+    }
+
+    @Test func majorVersionBumpIsDetectedRegardlessOfComponentCount() async throws {
+        #expect(UpdateChecker.isVersionNewer("2.0.0", than: "1.5") == true)
+    }
+
+    @Test func identicalVersionsAreNotNewer() async throws {
+        #expect(UpdateChecker.isVersionNewer("2.1.0", than: "2.1.0") == false)
+    }
+
+    @Test func olderVersionIsNotNewer() async throws {
+        #expect(UpdateChecker.isVersionNewer("2.0.9", than: "2.1.0") == false)
+    }
+
+    @Test func doubleDigitMinorVersionComparesNumericallyNotLexically() async throws {
+        #expect(UpdateChecker.isVersionNewer("1.10", than: "1.9") == true)
+    }
+
+    @Test func malformedVersionStringsAreNotTreatedAsNewer() async throws {
+        #expect(UpdateChecker.isVersionNewer("not-a-version", than: "2.1.0") == false)
+        #expect(UpdateChecker.isVersionNewer("2.1.0", than: "not-a-version") == false)
     }
 
 }


### PR DESCRIPTION
While reading through `UpdateChecker.swift` I noticed the version comparison has a gap: it only compares patch numbers when *both* the running version and the latest release tag have three components (`major.minor.patch`). If the installed build reports a two-component version like `2.1` and a patch-only release gets tagged `v2.1.5`, that branch is skipped entirely and the function falls through to `return false` - so "Check for Updates" would report you're already on the latest version even though you're not.

This repo's own release history shows both formats have actually been used (`1.1`-`1.5` were two-component, `1.0.0`/`2.0.0`/`2.0.1`/`2.1.0` are three-component), so this isn't a purely theoretical case - a future patch-only tag against a version built with two components would hit it.

**The fix:** rewrote `isNewerVersion` to compare both version strings component by component, treating a missing trailing component as `0`. That way `2.1` is compared as `2.1.0`, and a `2.1.5` release is correctly recognized as newer regardless of how many components either string has. I pulled the comparison out into a static `isVersionNewer(_:than:)` function so it's independent of the network callback and the `currentVersion` instance state, which makes it directly testable.

I also filled in the placeholder test file with real coverage for this function: the fixed case, a same-length patch bump, a major-version bump across different component counts, equal versions, an older version, double-digit component comparison (so it's confirmed to compare numerically and not lexically), and malformed input. Reverting just the comparison logic locally and re-running the suite confirms exactly one test fails without the fix (the shorter-current-version case), and all eight pass with it.

## Testing
- `xcodebuild build -scheme DockAnchor -destination 'platform=macOS' -configuration Debug` - succeeds
- `xcodebuild test -scheme DockAnchor -destination 'platform=macOS' -configuration Debug -only-testing:DockAnchorTests` - all 8 tests pass
- Confirmed the new test fails against the original comparison logic and passes against the fix (isolated regression check)

This is a self-contained change to the version-comparison logic and its tests - nothing else in `UpdateChecker` or elsewhere was touched.